### PR TITLE
Share booking now uses correct time and date

### DIFF
--- a/lib/tabs/booking_item.dart
+++ b/lib/tabs/booking_item.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_application_1/tabs/detailed_view.dart';
 import 'package:add_2_calendar/add_2_calendar.dart';
 
+import 'bookings.dart';
+
 ///This class represents an item that populates bookingList in the
 ///Bookings class.
 class BookingItem extends StatelessWidget {
   final String _roomName;
   final String _place;
   final String _address;
-  final String _date;
+  final Date _date;
   final String _description;
   final String _timeslot;
   final String _attribute;
@@ -86,7 +88,7 @@ class BookingItem extends StatelessWidget {
         return AlertDialog(
           title: Text(_roomName + ', ' + _workspaceNr),
           content: DetailedView(
-              _place, _address, _date, _description, _timeslot, _attribute),
+              _place, _address, _date.toString(), _description, _timeslot, _attribute),
           elevation: 24.0,
           actions: <Widget>[
             TextButton(
@@ -114,15 +116,7 @@ class BookingItem extends StatelessWidget {
               ),
             ),
             IconButton(
-              onPressed: () {
-                Add2Calendar.addEvent2Cal(Event(
-                  title: "Workspace "+_workspaceNr+" in "+_roomName+" booked at "+_place, // TODO use firebase data
-                  description: 'Workspace with '+_attribute+" booked in "+_roomName+", "+_description,
-                  location: _address,
-                  startDate: DateTime(2022,05,17,08,00), // TODO parse from _date and _timeslot
-                  endDate: DateTime(2022,05,17,17,00), // TODO parse from _date and _timeslot
-                ));
-              },
+              onPressed: _addToCalendar,
               icon: const Icon(Icons.share),
             ),
           ],
@@ -131,4 +125,24 @@ class BookingItem extends StatelessWidget {
       },
     );
   }
+
+  /// Function to open phone calendar to add the current booking to it
+  void _addToCalendar() {
+          int startTimeHour = int.parse(_timeslot.substring(8,10));
+          int startTimeMinute = int.parse(_timeslot.substring(11,13));
+  
+          int endTimeHour = int.parse(_timeslot.substring(20,22));
+          int endTimeMinute = int.parse(_timeslot.substring(23,25));
+  
+          DateTime start = DateTime(_date.year,_date.month,_date.day,startTimeHour,startTimeMinute);
+          DateTime end = DateTime(_date.year,_date.month,_date.day,endTimeHour,endTimeMinute);
+  
+          Add2Calendar.addEvent2Cal(Event(
+            title: "Workspace "+_workspaceNr+" in "+_roomName+" booked at "+_place,
+            description: 'Workspace with '+_attribute+" booked in "+_roomName+", "+_description,
+            location: _address,
+            startDate: start,
+            endDate: end,
+          ));
+        }
 }

--- a/lib/tabs/bookings.dart
+++ b/lib/tabs/bookings.dart
@@ -55,13 +55,13 @@ class _BookingsState extends State<Bookings> {
     }
 
     var myBookings = <Widget>[];
-    _Date previousDay = const _Date(0, 0, 0);
+    Date previousDay = const Date(0, 0, 0);
 
     for (Booking booking in bookings) {
-      _Date currentDay =
-          _Date(booking.day.year, booking.day.month, booking.day.day);
+      Date currentDay =
+          Date(booking.day.year, booking.day.month, booking.day.day);
       DateTime now = DateTime.now();
-      _Date today = _Date(now.year, now.month, now.day);
+      Date today = Date(now.year, now.month, now.day);
 
       //TODO Gettolösning, borde kanske radera gamla bokningar i backenden.
       if (currentDay.lessThan(today)) {
@@ -92,7 +92,7 @@ class _BookingsState extends State<Bookings> {
             room.name, // "[Rumsnamn]",
             room.office,// "[Plats]",
             backend.getOffices()[room.office]!.address,// "[Adress]",
-            currentDay.toString(),
+            currentDay,//.toString(),
             room.description,// "[Description]",
             room.timeslots[booking.timeslot].toString(),// "[Timeslot]",
             room.workspaces[booking.roomNr].toString(),// "[Attribut]",
@@ -107,11 +107,11 @@ class _BookingsState extends State<Bookings> {
 
 /// Class representing a date with a year, month and day.
 /// Contains methods for comparing dates.
-class _Date {
+class Date {
   final int year;
   final int month;
   final int day;
-  const _Date(this.year, this.month, this.day);
+  const Date(this.year, this.month, this.day);
 
   static const List<String> months = [
     'January',
@@ -128,11 +128,11 @@ class _Date {
     'December'
   ];
 
-  bool equals(_Date date2) {
+  bool equals(Date date2) {
     return year == date2.year && month == date2.month && day == date2.day;
   }
 
-  bool lessThan(_Date date2) {
+  bool lessThan(Date date2) {
     if (year < date2.year) {
       return true;
     }


### PR DESCRIPTION
I needed to turn the Date class in bookings.dart public in order to use it in booking_item. This is necessary as it would not be feasible to parse a date in string-format with different lengths depending on the month.

Preferably, the Date class could be replaced by Dart's DateTime-class, but this is probably not possible within our timeframe.